### PR TITLE
Add codecs to MediaReader constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,4 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+/EmguFFmpeg.Example/ffmpeg

--- a/EmguFFmpeg.EmguCV/EmguFFmpeg.EmguCV.csproj
+++ b/EmguFFmpeg.EmguCV/EmguFFmpeg.EmguCV.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Description>EmguFFmpeg with EmguCV expansian.</Description>
@@ -57,7 +57,8 @@ MediaFrame and Mat convert to each other</PackageReleaseNotes>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EMGU.CV" Version="4.1.1.3497" />
+    <PackageReference Include="Emgu.CV" Version="4.3.0.3890" />
+    <PackageReference Include="Emgu.CV.runtime.windows" Version="4.3.0.3890" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EmguFFmpeg.Example/DecodeVideoWithCustomCodecScaledToMat.cs
+++ b/EmguFFmpeg.Example/DecodeVideoWithCustomCodecScaledToMat.cs
@@ -1,0 +1,67 @@
+﻿using EmguFFmpeg.EmguCV;
+
+using FFmpeg.AutoGen;
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace EmguFFmpeg.Example
+{
+    internal class DecodeVideoWithCustomCodecScaledToMat
+    {
+        /// <summary>
+        /// decode video to image
+        /// </summary>
+        /// <param name="inputFile">input video file</param>
+        /// <param name="outDirectory">folder for output image files</param>
+        public unsafe DecodeVideoWithCustomCodecScaledToMat(string inputFile, string outDirectory)
+        {
+            // !!!  IMPORTANT NOTE: This sample won't work, if you haven't downloaded ffmpeg (GPL license, as it is more complete), and you don't have NVIDIA hardware (CUDA) !!!
+            
+            using (MediaReader reader = new MediaReader(inputFile, null, null, "h264_cuvid", null))
+            {
+                var videoIndex = reader.First(_ => _.Codec.AVCodecContext.codec_type == AVMediaType.AVMEDIA_TYPE_VIDEO).Index;
+                int height = reader[videoIndex].Codec.AVCodecContext.height;
+                int width = reader[videoIndex].Codec.AVCodecContext.width;
+                int format = (int)reader[videoIndex].Codec.AVCodecContext.pix_fmt;
+                AVRational time_base = reader[videoIndex].TimeBase;
+                AVRational sample_aspect_ratio = reader[videoIndex].Codec.AVCodecContext.sample_aspect_ratio;
+
+                /* We are moving the packet to CUDA to perform the scaling.
+                 We can then:
+                 - remove hwdownload and format to leave it in CUDA, and forward the pointer to any other function, or write the frame to the output video
+                 - convert it to MAT whereas converting speed depends on the size of the scaled frame.
+                */
+                MediaFilterGraph filterGraph = new MediaFilterGraph();
+                filterGraph.AddVideoSrcFilter(new MediaFilter(MediaFilter.VideoSources.Buffer), width, height, (AVPixelFormat)format, time_base, sample_aspect_ratio)
+                    .LinkTo(0, filterGraph.AddFilter(new MediaFilter("scale"), "512:288"))
+                    .LinkTo(0, filterGraph.AddVideoSinkFilter(new MediaFilter(MediaFilter.VideoSinks.Buffersink)));
+                filterGraph.Initialize();
+
+                var sw = new Stopwatch();
+                sw.Start();
+
+                foreach (var packet in reader.ReadPacket())
+                {
+                    foreach (var frame in reader[videoIndex].ReadFrame(packet))
+                    {
+                        filterGraph.Inputs.First().WriteFrame(frame);
+                        foreach (var filterFrame in filterGraph.Outputs.First().ReadFrame())
+                        {
+                            using (var image = filterFrame.ToMat())
+                            {
+                                sw.Stop();
+                                Console.WriteLine($"Converting to MAT [ processed in {sw.Elapsed.TotalMilliseconds:0} ms ]");
+                            }
+
+                            sw = new Stopwatch();
+                            sw.Start();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/EmguFFmpeg.Example/EmguFFmpeg.Example.csproj
+++ b/EmguFFmpeg.Example/EmguFFmpeg.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -13,9 +13,58 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EmguFFmpeg.EmguCV\EmguFFmpeg.EmguCV.csproj" />
+    <ProjectReference Include="..\EmguFFmpeg.OpenCvSharp\EmguFFmpeg.OpenCvSharp.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="PresentationFramework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="ffmpeg\avcodec-58.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\avdevice-58.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\avfilter-7.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\avformat-58.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\avutil-56.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\ffmpeg.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\ffplay.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\ffprobe.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\libwinpthread-1.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\nvEncodeAPI64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\postproc-55.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\swresample-3.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg\swscale-5.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="fonts\RobotoCondensed-Bold.ttf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="images\overlay_sample.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/EmguFFmpeg.Example/Program.cs
+++ b/EmguFFmpeg.Example/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Emgu.CV;
 using System;
 using System.Diagnostics;
+using System.IO;
 using EmguFFmpeg.EmguCV;
 using FFmpeg.AutoGen;
 using System.Runtime.InteropServices;
@@ -12,7 +13,7 @@ namespace EmguFFmpeg.Example
         private unsafe static void Main(string[] args)
         {
             Process.Start(Environment.CurrentDirectory);
-            FFmpegHelper.RegisterBinaries();
+            FFmpegHelper.RegisterBinaries(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "ffmpeg"));
             FFmpegHelper.SetupLogging(logWrite: _ => Trace.Write(_));
             Console.WriteLine("Hello FFmpeg!");
 
@@ -23,7 +24,8 @@ namespace EmguFFmpeg.Example
             //EncodeAudioByMat encodeAudio = new EncodeAudioByMat("output.mp3");
             //EncodeVideoByMat video = new EncodeVideoByMat("output.mp4", 800, 600, 1);
             //DecodeVideoToMat videoToImage = new DecodeVideoToMat(@"C:\Users\Admin\Videos\Desktop\input.mp4", "image");
-            //DecodeVideoToMat videoToImage = new DecodeVideoToMat(@"C:\Users\Admin\Desktop\out9.webm", "image");
+            DecodeVideoWithCustomCodecScaledToMat videoScaledToMat =
+                new DecodeVideoWithCustomCodecScaledToMat(@"C:\t\x.mp4", "image");            //DecodeVideoToMat videoToImage = new DecodeVideoToMat(@"C:\Users\Admin\Desktop\out9.webm", "image");
 
             Console.ReadKey();
         }

--- a/EmguFFmpeg/FFmpegHelper.cs
+++ b/EmguFFmpeg/FFmpegHelper.cs
@@ -101,7 +101,7 @@ namespace EmguFFmpeg
             return result;
         }
 
-        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
+        [DllImport("kernel32.dll", EntryPoint = "RtlCopyMemory", SetLastError = false)]
         private static extern void CopyMemoryInternal(IntPtr dest, IntPtr src, uint count);
 
         /// <summary>


### PR DESCRIPTION
Specifying the codec when creating MediaReader enables developer to use the an alternative codec, which might have a better performance.

Note that I also refactored code to use ffmpeg sub-folder for binaries, and upgraded project to use .NET Framework 4.6.1, and EmguCV 4.3.0.3890 (4.6.1. is minimum requirement for the latest EmguCV).

The major benefit of this commit is to get scaled video converted to mat in 20ms which is even faster than video itself (30fps = 33.33ms).

Thanks