### PR TITLE
Decoder support hardware acceleration

### DIFF
--- a/src/EmguFFmpeg.csproj
+++ b/src/EmguFFmpeg.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageId>EmguFFmpeg</PackageId>
     <Description>
       A FFmpeg.AutoGen Warpper Library.

--- a/src/MediaCodec/MediaDecoder.cs
+++ b/src/MediaCodec/MediaDecoder.cs
@@ -133,6 +133,18 @@ namespace EmguFFmpeg
         {
             if (pCodecContext == null)
                 throw new FFmpegException(FFmpegException.NotInitCodecContext);
+
+            if (pCodecContext->hw_device_ctx != null)
+            {
+                using (MediaFrame pFrame = new VideoFrame())
+                {
+                    int frameStatus = ffmpeg.avcodec_receive_frame(pCodecContext, pFrame);
+                    if (frameStatus < 0)
+                        return frameStatus;
+                    int status = ffmpeg.av_hwframe_transfer_data(frame, pFrame, 0);
+                    return status;
+                }
+            }
             return ffmpeg.avcodec_receive_frame(pCodecContext, frame);
         }
         #endregion

--- a/src/MediaMux/MediaReader.cs
+++ b/src/MediaMux/MediaReader.cs
@@ -20,8 +20,8 @@ namespace EmguFFmpeg
         /// <param name="stream"></param>
         /// <param name="iformat"></param>
         /// <param name="options"></param>
-        public MediaReader(Stream stream, InFormat iformat = null, MediaDictionary options = null)
-            : this(stream, 4096, iformat, options) { }
+        public MediaReader(Stream stream, InFormat iformat = null, MediaDictionary options = null, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
+            : this(stream, 4096, iformat, options, HWDeviceType) { }
 
         /// <summary>
         /// Load stream with buffersize
@@ -30,7 +30,7 @@ namespace EmguFFmpeg
         /// <param name="buffersize"></param>
         /// <param name="iformat"></param>
         /// <param name="options"></param>
-        public MediaReader(Stream stream, int buffersize, InFormat iformat = null, MediaDictionary options = null)
+        public MediaReader(Stream stream, int buffersize, InFormat iformat = null, MediaDictionary options = null, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
         {
             baseStream = stream;
             bufferLength = buffersize;
@@ -52,6 +52,11 @@ namespace EmguFFmpeg
                 AVStream* pStream = pFormatContext->streams[i];
                 MediaDecoder codec = MediaDecoder.CreateDecoder(pStream->codecpar->codec_id, _ =>
                 {
+                    if (pStream->codecpar->codec_type is AVMediaType.AVMEDIA_TYPE_VIDEO && HWDeviceType != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
+                    {
+                        AVCodecContext* _pCodecContext = _;
+                        ffmpeg.av_hwdevice_ctx_create(&_pCodecContext->hw_device_ctx, HWDeviceType, null, null, 0).ThrowIfError();
+                    }
                     ffmpeg.avcodec_parameters_to_context(_, pStream->codecpar);
                 });
                 streams.Add(new MediaStream(pStream) { Codec = codec });
@@ -64,7 +69,7 @@ namespace EmguFFmpeg
         /// <param name="url"></param>
         /// <param name="iformat"></param>
         /// <param name="options"></param>
-        public MediaReader(string url, InFormat iformat = null, MediaDictionary options = null)
+        public MediaReader(string url, InFormat iformat = null, MediaDictionary options = null, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
         {
             fixed (AVFormatContext** ppFormatContext = &pFormatContext)
             {
@@ -78,6 +83,11 @@ namespace EmguFFmpeg
                 AVStream* pStream = pFormatContext->streams[i];
                 MediaDecoder codec = MediaDecoder.CreateDecoder(pStream->codecpar->codec_id, _ =>
                 {
+                    if (pStream->codecpar->codec_type is AVMediaType.AVMEDIA_TYPE_VIDEO && HWDeviceType != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
+                    {
+                        AVCodecContext* _pCodecContext = _;
+                        ffmpeg.av_hwdevice_ctx_create(&_pCodecContext->hw_device_ctx, HWDeviceType, null, null, 0).ThrowIfError();
+                    }
                     ffmpeg.avcodec_parameters_to_context(_, pStream->codecpar);
                 });
                 streams.Add(new MediaStream(pStream) { Codec = codec });


### PR DESCRIPTION
Issue: https://github.com/IOL0ol1/EmguFFmpeg/issues/10
Refer to: https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/master/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs

But different AVHWDeviceType needs to correspond to different AVPixelFormat (Untreated in this pr)
https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/187cdbcea2d9208ea94a3041a5b2aac1d268b297/FFmpeg.AutoGen.Example/Program.cs#L129
https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/187cdbcea2d9208ea94a3041a5b2aac1d268b297/FFmpeg.AutoGen.Example/Program.cs#L103