### PR TITLE
Fix AddAudioSrcFilter in MediaFilterGraph and several enhancements

### DIFF
--- a/src/FFmpegHelper.cs
+++ b/src/FFmpegHelper.cs
@@ -23,7 +23,7 @@ namespace EmguFFmpeg
         /// <param name="logLevel">log level</param>
         /// <param name="logFlags">log flags, support &amp; operator </param>
         /// <param name="logWrite">set <see langword="null"/> to use default log output</param>
-        public static void SetupLogging(LogLevel logLevel = LogLevel.Verbose, LogFlags logFlags = LogFlags.PrintLevel, Action<string> logWrite = null)
+        public static void SetupLogging(LogLevel logLevel = LogLevel.Verbose, LogFlags logFlags = LogFlags.PrintLevel, Action<string, int> logWrite = null)
         {
             ffmpeg.av_log_set_level((int)logLevel);
             ffmpeg.av_log_set_flags((int)logFlags);
@@ -41,7 +41,7 @@ namespace EmguFFmpeg
                     var printPrefix = 1;
                     var lineBuffer = stackalloc byte[lineSize];
                     ffmpeg.av_log_format_line(p0, level, format, vl, lineBuffer, lineSize, &printPrefix);
-                    logWrite.Invoke(((IntPtr)lineBuffer).PtrToStringUTF8());
+                    logWrite.Invoke(((IntPtr)lineBuffer).PtrToStringUTF8(), level);
                 };
             }
             ffmpeg.av_log_set_callback(logCallback);
@@ -252,6 +252,9 @@ namespace EmguFFmpeg
         /// <see cref="ffmpeg.AV_LOG_VERBOSE"/>
         /// </summary>
         Verbose = ffmpeg.AV_LOG_VERBOSE,
+        /// <see cref="ffmpeg.AV_LOG_INFO"/>
+        /// </summary>
+        Info = ffmpeg.AV_LOG_INFO,
         /// <summary>
         /// <see cref="ffmpeg.AV_LOG_WARNING"/>
         /// </summary>

--- a/src/MediaDictionary.cs
+++ b/src/MediaDictionary.cs
@@ -119,6 +119,16 @@ namespace EmguFFmpeg
             }
         }
 
+        public MediaDictionary Copy()
+        {
+            MediaDictionary result = new MediaDictionary();
+            foreach (KeyValuePair<string, string> entry in this)
+            {
+                result.Add(entry.Key, entry.Value);
+            }
+            return result;
+        }
+
         #region IEnumerator
         private static IntPtr av_dict_get_safe(MediaDictionary dict, string key, IntPtr prev, AVDictReadFlags flags)
         {

--- a/src/MediaFilter/MediaFilterGraph.cs
+++ b/src/MediaFilter/MediaFilterGraph.cs
@@ -49,6 +49,16 @@ namespace EmguFFmpeg
             return filterContext;
         }
 
+        public MediaFilterContext AddVideoSrcFilter(MediaFilter filter,  string options = null, string contextName = null)
+        {
+            MediaFilterContext filterContext = AddFilter(filter, options, contextName);
+            if (filterContext.NbInputs > 0)
+                throw new FFmpegException(FFmpegException.NotSourcesFilter);
+            if (ffmpeg.avfilter_pad_get_type(filterContext.AVFilterContext.output_pads, 0) != AVMediaType.AVMEDIA_TYPE_VIDEO)
+                throw new FFmpegException(FFmpegException.FilterTypeError);
+            return filterContext;
+        }
+
         public MediaFilterContext AddVideoSinkFilter(MediaFilter filter, AVPixelFormat[] formats = null, string contextName = null)
         {
             MediaFilterContext filterContext = AddFilter(filter, _ =>
@@ -82,11 +92,16 @@ namespace EmguFFmpeg
                     ffmpeg.av_opt_set_int(_, "sample_rate", samplerate, ffmpeg.AV_OPT_SEARCH_CHILDREN);
                 }
             }, contextName);
-            if (filterContext.NbOutputs > 0)
+            if (filterContext.NbInputs > 0)
                 throw new FFmpegException(FFmpegException.NotSourcesFilter);
             if (ffmpeg.avfilter_pad_get_type(filterContext.AVFilterContext.input_pads, 0) != AVMediaType.AVMEDIA_TYPE_AUDIO)
                 throw new FFmpegException(FFmpegException.FilterTypeError);
             return filterContext;
+        }
+
+        public MediaFilterContext AddAudioSrcFilter(MediaFilter filter, string options = null, string contextName = null)
+        {
+            return AddVideoSrcFilter(filter, options, contextName);
         }
 
         public MediaFilterContext AddAudioSinkFilter(MediaFilter filter, AVSampleFormat[] formats = null, int[] sampleRates = null, ulong[] channelLayouts = null, int[] channelCounts = null, int allChannelCounts = 0, string contextName = null)

--- a/src/MediaFrame/MediaFrame.cs
+++ b/src/MediaFrame/MediaFrame.cs
@@ -147,6 +147,18 @@ namespace EmguFFmpeg
             set => pFrame->pts = value;
         }
 
+        public long Dts
+        {
+            get => pFrame->pkt_dts;
+            set => pFrame->pkt_dts = value;
+        }
+
+        public long Duration
+        {
+            get => pFrame->pkt_duration;
+            set => pFrame->pkt_duration = value;
+        }
+
         public int SampleRate
         {
             get => pFrame->sample_rate;

--- a/src/MediaMux/MediaReader.cs
+++ b/src/MediaMux/MediaReader.cs
@@ -50,10 +50,12 @@ namespace EmguFFmpeg
             for (int i = 0; i < pFormatContext->nb_streams; i++)
             {
                 AVStream* pStream = pFormatContext->streams[i];
-                MediaDecoder codec = MediaDecoder.CreateDecoder(pStream->codecpar->codec_id, _ =>
-                {
-                    ffmpeg.avcodec_parameters_to_context(_, pStream->codecpar);
-                });
+                var codecId = pStream->codecpar->codec_id;
+                var codec = codecId != AVCodecID.AV_CODEC_ID_NONE
+                    ? MediaDecoder.CreateDecoder(
+                        codecId,
+                        _ => ffmpeg.avcodec_parameters_to_context(_, pStream->codecpar))
+                    : null;
                 streams.Add(new MediaStream(pStream) { Codec = codec });
             }
         }
@@ -76,10 +78,12 @@ namespace EmguFFmpeg
             for (int i = 0; i < pFormatContext->nb_streams; i++)
             {
                 AVStream* pStream = pFormatContext->streams[i];
-                MediaDecoder codec = MediaDecoder.CreateDecoder(pStream->codecpar->codec_id, _ =>
-                {
-                    ffmpeg.avcodec_parameters_to_context(_, pStream->codecpar);
-                });
+                var codecId = pStream->codecpar->codec_id;
+                var codec = codecId != AVCodecID.AV_CODEC_ID_NONE
+                                    ? MediaDecoder.CreateDecoder(
+                                        codecId,
+                                        _ => ffmpeg.avcodec_parameters_to_context(_, pStream->codecpar))
+                                    : null;
                 streams.Add(new MediaStream(pStream) { Codec = codec });
             }
         }


### PR DESCRIPTION
**MediaFilterGraph**: 

- Fix bug in `AddAudioSrcFilter` where `NbOutputs` was tested instead of `NbInputs`
- Add new methods to add video (or audio) source filter like **"color, "nullsrc", "anullsrc"** with options

**MediaDictionary:** 

- Add `Copy` method

**MediaFrame:** 

- Add `Dts` and `Duration` as public properties

**FFmpegHelper:** 

- `SetupLogging` updated to get also log level

**MediaReader:** 

- Avoid to create decoder if `codecId` equals `AVCodecID.AV_CODEC_ID_NONE`